### PR TITLE
Two fixes to prevent memory leak from occuring.

### DIFF
--- a/apptentive-android-sdk/src/com/apptentive/android/sdk/Apptentive.java
+++ b/apptentive-android-sdk/src/com/apptentive/android/sdk/Apptentive.java
@@ -97,6 +97,7 @@ public class Apptentive {
 	 */
 	public static void onStop(Activity activity) {
 		ActivityLifecycleManager.activityStopped(activity);
+		NetworkStateReceiver.clearListeners();
 	}
 
 	/**

--- a/apptentive-android-sdk/src/com/apptentive/android/sdk/storage/ApptentiveDatabase.java
+++ b/apptentive-android-sdk/src/com/apptentive/android/sdk/storage/ApptentiveDatabase.java
@@ -98,7 +98,7 @@ public class ApptentiveDatabase extends SQLiteOpenHelper implements PayloadStore
 
 	public static ApptentiveDatabase getInstance(Context context) {
 		if (instance == null) {
-			instance = new ApptentiveDatabase(context);
+			instance = new ApptentiveDatabase(context.getApplicationContext());
 		}
 		return instance;
 	}


### PR DESCRIPTION
I'm using Apptentive in one of my apps inside multiple activities, and I was debugging some memory issues. I noticed that some of these activities were being held onto after they've been finished by Apptentive. These two changes seem to fix the issue.

I've also attached a screenshot from Eclipse MemoryAnalyzer showing the problem. The IntroActivity_ that is shown has already been finished. But it still shows up in the memory dump, and when I check the path to GC root these two references show up (along with another library with the same problem).

Let me know if you have any questions.

![eclipse_memory_analyzer](https://f.cloud.github.com/assets/1022833/1443536/cda82316-41e8-11e3-9a1f-1a7d904c530e.png)
