### PR TITLE
Fix memory leak caused by passing activity context to new Thread

### DIFF
--- a/apptentive-android-sdk/src/com/apptentive/android/sdk/Apptentive.java
+++ b/apptentive-android-sdk/src/com/apptentive/android/sdk/Apptentive.java
@@ -63,7 +63,7 @@ public class Apptentive {
 	 */
 	public static void onStart(Activity activity) {
 		try {
-			init(activity);
+			init(activity.getApplicationContext());
 			ActivityLifecycleManager.activityStarted(activity);
 			PayloadSendWorker.activityStarted(activity.getApplicationContext());
 			MessagePollingWorker.start(activity.getApplicationContext());


### PR DESCRIPTION
Passing the Activity Context to new a Thread is causing a memory leak. 

To reproduce the leak on ICS or higher add  StrictMode.enableDefaults() to your Application or Activities onCreate.  After starting the app rotate the device a few times.  You we see something similar to  
android.os.StrictMode$InstanceCountViolation: class Your com.example.YourActivity; instances=2; limit=1 in logcat.  After every device rotation instances will increment.  After a few device rotations you can do a heap dump and then import in into MAT.

Once you have imported the heap dump into MAT got the histogram and search for your activity.  Select it and  right click on it go to Merge Shortest Paths to GC Roots -> exclude all weak references and you will see something similar the following
![screen shot 2014-06-17 at 11 02 49 am](https://cloud.githubusercontent.com/assets/547325/3303610/4f4d5a46-f641-11e3-8aed-49479fc7ac90.png)

There should only be on instance in memory
