### PR TITLE
AND-31 - A large change allows InteractionViews to save instance state, ...

### DIFF
--- a/apptentive-android.iml
+++ b/apptentive-android.iml
@@ -8,8 +8,6 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <output url="file://$MODULE_DIR$/build/classes/main" />
-    <output-test url="file://$MODULE_DIR$/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />

--- a/apptentive-android.ipr
+++ b/apptentive-android.ipr
@@ -64,22 +64,6 @@
     </option>
   </component>
   <component name="IdProvider" IDEtalkID="559664322781B77446E3F5CE3A937CE9" />
-  <component name="InspectionProjectProfileManager">
-    <profiles>
-      <profile version="1.0" is_locked="false">
-        <option name="myName" value="Project Default" />
-        <option name="myLocal" value="false" />
-        <inspection_tool class="SpellCheckingInspection" enabled="true" level="TYPO" enabled_by_default="true">
-          <option name="processCode" value="false" />
-          <option name="processLiterals" value="true" />
-          <option name="processComments" value="true" />
-        </inspection_tool>
-      </profile>
-    </profiles>
-    <option name="PROJECT_PROFILE" value="Project Default" />
-    <option name="USE_PROJECT_PROFILE" value="true" />
-    <version value="1.0" />
-  </component>
   <component name="JavadocGenerationManager">
     <option name="OUTPUT_DIRECTORY" value="$PROJECT_DIR$/out/javadoc" />
     <option name="OPTION_SCOPE" value="public" />

--- a/apptentive/apptentive.iml
+++ b/apptentive/apptentive.iml
@@ -80,10 +80,9 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/poms" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 15 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android 4.0.3 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/apptentive/src/com/apptentive/android/sdk/module/ActivityContent.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/ActivityContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Apptentive, Inc. All Rights Reserved.
+ * Copyright (c) 2015, Apptentive, Inc. All Rights Reserved.
  * Please refer to the LICENSE file for the terms and conditions
  * under which redistribution and use of this file is permitted.
  */
@@ -7,6 +7,7 @@
 package com.apptentive.android.sdk.module;
 
 import android.app.Activity;
+import android.os.Bundle;
 import com.apptentive.android.sdk.Log;
 
 /**
@@ -18,7 +19,9 @@ public abstract class ActivityContent {
 
 	protected Type type;
 
-	public abstract void onStop();
+	public abstract void onCreate(Activity activity, Bundle onSavedInstanceState);
+	public abstract void onSaveInstanceState(Bundle outState);
+	public abstract void onRestoreInstanceState(Bundle savedInstanceState);
 
 	/**
 	 * Called from the container Activity when the Android back button is pressed. When done processing the back button,
@@ -28,8 +31,6 @@ public abstract class ActivityContent {
 	 * @return True if this back button press should propagate back to the parent object, else false.
 	 */
 	public abstract boolean onBackPressed(Activity activity);
-
-	public abstract void show(Activity activity);
 
 	public Type getType() {
 		return type;

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/model/AppStoreRatingInteraction.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/model/AppStoreRatingInteraction.java
@@ -6,6 +6,7 @@
 
 package com.apptentive.android.sdk.module.engagement.interaction.model;
 
+import android.app.Activity;
 import org.json.JSONException;
 
 /**
@@ -17,5 +18,10 @@ public class AppStoreRatingInteraction extends Interaction {
 
 	public AppStoreRatingInteraction(String json) throws JSONException {
 		super(json);
+	}
+
+	@Override
+	public void sendLaunchEvent(Activity activity) {
+		// This Interaction type does not send a launch Event.
 	}
 }

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/model/Interaction.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/model/Interaction.java
@@ -6,8 +6,10 @@
 
 package com.apptentive.android.sdk.module.engagement.interaction.model;
 
+import android.app.Activity;
 import android.content.Context;
 import com.apptentive.android.sdk.Log;
+import com.apptentive.android.sdk.module.engagement.EngagementModule;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -23,8 +25,14 @@ public abstract class Interaction extends JSONObject {
 	private static final String KEY_VERSION = "version";
 	private static final String KEY_CONFIGURATION = "configuration";
 
+	public static final String EVENT_NAME_LAUNCH = "launch";
+
 	public Interaction(String json) throws JSONException {
 		super(json);
+	}
+
+	public void sendLaunchEvent(Activity activity) {
+		EngagementModule.engageInternal(activity, this, Interaction.EVENT_NAME_LAUNCH);
 	}
 
 	/**

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/model/NavigateToLinkInteraction.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/model/NavigateToLinkInteraction.java
@@ -6,6 +6,7 @@
 
 package com.apptentive.android.sdk.module.engagement.interaction.model;
 
+import android.app.Activity;
 import org.json.JSONException;
 
 import java.util.Locale;
@@ -42,7 +43,7 @@ public class NavigateToLinkInteraction extends Interaction {
 		return Target.New;
 	}
 
-	public static enum Target {
+	public enum Target {
 		New, // Default value
 		Self;
 
@@ -65,5 +66,10 @@ public class NavigateToLinkInteraction extends Interaction {
 			}
 			return New;
 		}
+	}
+
+	@Override
+	public void sendLaunchEvent(Activity activity) {
+		// This Interaction type does not send a launch Event.
 	}
 }

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/model/TextModalInteraction.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/model/TextModalInteraction.java
@@ -19,7 +19,6 @@ public class TextModalInteraction extends Interaction {
 	private static final String KEY_BODY = "body";
 	private static final String KEY_ACTIONS = "actions";
 
-	public static final String EVENT_NAME_LAUNCH = "launch";
 	public static final String EVENT_NAME_CANCEL = "cancel";
 	public static final String EVENT_NAME_DISMISS = "dismiss";
 	public static final String EVENT_NAME_INTERACTION = "interaction";
@@ -31,21 +30,6 @@ public class TextModalInteraction extends Interaction {
 
 	public TextModalInteraction(String json) throws JSONException {
 		super(json);
-	}
-
-	public static enum Layout {
-		center,
-		bottom,
-		unknown;
-
-		public static Layout parse(String name) {
-			try {
-				return Layout.valueOf(name);
-			} catch (IllegalArgumentException e) {
-				Log.v("Error parsing unknown TextModalInteraction.Layout: " + name);
-			}
-			return unknown;
-		}
 	}
 
 	public String getTitle() {

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/model/survey/SurveyState.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/model/survey/SurveyState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Apptentive, Inc. All Rights Reserved.
+ * Copyright (c) 2015, Apptentive, Inc. All Rights Reserved.
  * Please refer to the LICENSE file for the terms and conditions
  * under which redistribution and use of this file is permitted.
  */
@@ -15,8 +15,6 @@ import java.util.*;
  * @author Sky Kelsey
  */
 public class SurveyState {
-
-	private boolean surveyLaunchSent;
 
 	private Map<String, Set<String>> questionToAnswersMap;
 	private Map<String, Integer> questionToMinAnswersMap;
@@ -36,14 +34,6 @@ public class SurveyState {
 			questionToMaxAnswersMap.put(questionId, question.getMaxSelections());
 			questionToMetricSentMap.put(questionId, false);
 		}
-	}
-
-	public void setSurveyLaunchSent() {
-		surveyLaunchSent = true;
-	}
-
-	public boolean isSurveyLaunchSent() {
-		return surveyLaunchSent;
 	}
 
 	public void addAnswer(String questionId, String answer) {

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/AppStoreRatingInteractionView.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/AppStoreRatingInteractionView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Apptentive, Inc. All Rights Reserved.
+ * Copyright (c) 2015, Apptentive, Inc. All Rights Reserved.
  * Please refer to the LICENSE file for the terms and conditions
  * under which redistribution and use of this file is permitted.
  */
@@ -10,6 +10,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
+import android.os.Bundle;
 import com.apptentive.android.sdk.ApptentiveInternal;
 import com.apptentive.android.sdk.R;
 import com.apptentive.android.sdk.model.Configuration;
@@ -33,11 +34,8 @@ public class AppStoreRatingInteractionView extends InteractionView<AppStoreRatin
 	}
 
 	@Override
-	public void show(Activity activity) {
-		super.show(activity);
-
+	public void doOnCreate(Activity activity, Bundle savedInstanceState) {
 		// TODO: See if we can determine which app store the app was downloaded and go directly there.
-
 		String errorMessage = activity.getString(R.string.apptentive_rating_error);
 		try {
 			IRatingProvider ratingProvider = ApptentiveInternal.getRatingProvider();
@@ -59,8 +57,6 @@ public class AppStoreRatingInteractionView extends InteractionView<AppStoreRatin
 				finalRatingProviderArgs.put("name", appDisplayName);
 			}
 
-			// Engage, then start the rating.
-			//Apptentive.engageInternal(activity, interaction.getType().name(), CODE_POINT_RATE);
 			ratingProvider.startRating(activity, finalRatingProviderArgs);
 		} catch (ActivityNotFoundException e) {
 			displayError(activity, errorMessage);
@@ -70,10 +66,6 @@ public class AppStoreRatingInteractionView extends InteractionView<AppStoreRatin
 		} finally {
 			activity.finish();
 		}
-	}
-
-	@Override
-	public void onStop() {
 	}
 
 	@Override

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/EnjoymentDialogInteractionView.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/EnjoymentDialogInteractionView.java
@@ -7,6 +7,7 @@
 package com.apptentive.android.sdk.module.engagement.interaction.view;
 
 import android.app.Activity;
+import android.os.Bundle;
 import android.view.View;
 import android.widget.TextView;
 import com.apptentive.android.sdk.R;
@@ -19,7 +20,6 @@ import com.apptentive.android.sdk.module.engagement.interaction.view.common.Appt
  */
 public class EnjoymentDialogInteractionView extends InteractionView<EnjoymentDialogInteraction> {
 
-	private static final String CODE_POINT_LAUNCH = "launch";
 	private static final String CODE_POINT_CANCEL = "cancel";
 	private static final String CODE_POINT_YES = "yes";
 	private static final String CODE_POINT_NO = "no";
@@ -29,11 +29,8 @@ public class EnjoymentDialogInteractionView extends InteractionView<EnjoymentDia
 	}
 
 	@Override
-	public void show(final Activity activity) {
-		super.show(activity);
+	public void doOnCreate(final Activity activity, Bundle savedInstanceState) {
 		activity.setContentView(R.layout.apptentive_enjoyment_dialog_interaction);
-
-		EngagementModule.engageInternal(activity, interaction, CODE_POINT_LAUNCH);
 
 		TextView bodyView = (TextView) activity.findViewById(R.id.title);
 		String body = interaction.getTitle(activity);
@@ -66,11 +63,6 @@ public class EnjoymentDialogInteractionView extends InteractionView<EnjoymentDia
 				activity.finish();
 			}
 		});
-	}
-
-	@Override
-	public void onStop() {
-
 	}
 
 	@Override

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/InteractionView.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/InteractionView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Apptentive, Inc. All Rights Reserved.
+ * Copyright (c) 2015, Apptentive, Inc. All Rights Reserved.
  * Please refer to the LICENSE file for the terms and conditions
  * under which redistribution and use of this file is permitted.
  */
@@ -7,8 +7,10 @@
 package com.apptentive.android.sdk.module.engagement.interaction.view;
 
 import android.app.Activity;
+import android.os.Bundle;
 import com.apptentive.android.sdk.Log;
 import com.apptentive.android.sdk.module.ActivityContent;
+import com.apptentive.android.sdk.module.engagement.EngagementModule;
 import com.apptentive.android.sdk.module.engagement.interaction.model.Interaction;
 
 /**
@@ -18,11 +20,34 @@ public abstract class InteractionView<T extends Interaction> extends ActivityCon
 
 	protected T interaction;
 
+	private static final String HAS_LAUNCHED = "has_launched";
+	protected boolean hasLaunched;
+
 	public InteractionView(T interaction) {
 		this.interaction = interaction;
 	}
 
-	public void show(final Activity activity) {
+	public void onCreate(final Activity activity, Bundle savedInstanceState) {
 		Log.d("Showing interaction.");
+		if (savedInstanceState != null) {
+			hasLaunched = savedInstanceState.getBoolean(HAS_LAUNCHED);
+		}
+		if (!hasLaunched) {
+			hasLaunched = true;
+			interaction.sendLaunchEvent(activity);
+		}
+		doOnCreate(activity, savedInstanceState);
 	}
+
+	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		outState.putBoolean(HAS_LAUNCHED, hasLaunched);
+	}
+
+	@Override
+	public void onRestoreInstanceState(Bundle savedInstanceState) {
+		hasLaunched = savedInstanceState.getBoolean(HAS_LAUNCHED, false);
+	}
+
+	protected abstract void doOnCreate(Activity activity, Bundle savedInstanceState);
 }

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/NavigateToLinkInteractionView.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/NavigateToLinkInteractionView.java
@@ -10,6 +10,7 @@ import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Bundle;
 import com.apptentive.android.sdk.Log;
 import com.apptentive.android.sdk.module.engagement.EngagementModule;
 import com.apptentive.android.sdk.module.engagement.interaction.model.NavigateToLinkInteraction;
@@ -28,9 +29,7 @@ public class NavigateToLinkInteractionView extends InteractionView<NavigateToLin
 	}
 
 	@Override
-	public void show(Activity activity) {
-		super.show(activity);
-
+	public void doOnCreate(Activity activity, Bundle savedInteraction) {
 		boolean success = false;
 		try {
 			String url = interaction.getUrl();
@@ -64,10 +63,6 @@ public class NavigateToLinkInteractionView extends InteractionView<NavigateToLin
 			// Always finish this Activity.
 			activity.finish();
 		}
-	}
-
-	@Override
-	public void onStop() {
 	}
 
 	@Override

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/RatingDialogInteractionView.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/RatingDialogInteractionView.java
@@ -7,8 +7,8 @@
 package com.apptentive.android.sdk.module.engagement.interaction.view;
 
 import android.app.Activity;
+import android.os.Bundle;
 import android.view.View;
-import android.widget.Button;
 import android.widget.TextView;
 import com.apptentive.android.sdk.R;
 import com.apptentive.android.sdk.module.engagement.EngagementModule;
@@ -20,7 +20,6 @@ import com.apptentive.android.sdk.module.engagement.interaction.view.common.Appt
  */
 public class RatingDialogInteractionView extends InteractionView<RatingDialogInteraction> {
 
-	private static final String CODE_POINT_LAUNCH = "launch";
 	private static final String CODE_POINT_CANCEL = "cancel";
 	private static final String CODE_POINT_RATE = "rate";
 	private static final String CODE_POINT_REMIND = "remind";
@@ -31,11 +30,8 @@ public class RatingDialogInteractionView extends InteractionView<RatingDialogInt
 	}
 
 	@Override
-	public void show(final Activity activity) {
-		super.show(activity);
+	public void doOnCreate(final Activity activity, Bundle savedInstanceState) {
 		activity.setContentView(R.layout.apptentive_rating_dialog_interaction);
-
-		EngagementModule.engageInternal(activity, interaction, CODE_POINT_LAUNCH);
 
 		String title = interaction.getTitle();
 		if (title != null) {
@@ -86,10 +82,6 @@ public class RatingDialogInteractionView extends InteractionView<RatingDialogInt
 				activity.finish();
 			}
 		});
-	}
-
-	@Override
-	public void onStop() {
 	}
 
 	@Override

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/TextModalInteractionView.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/TextModalInteractionView.java
@@ -7,6 +7,7 @@
 package com.apptentive.android.sdk.module.engagement.interaction.view;
 
 import android.app.Activity;
+import android.os.Bundle;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -42,11 +43,9 @@ public class TextModalInteractionView extends InteractionView<TextModalInteracti
 	}
 
 	@Override
-	public void show(final Activity activity) {
-		super.show(activity);
+	public void doOnCreate(final Activity activity, Bundle onSavedInstanceState) {
 		activity.setContentView(R.layout.apptentive_textmodal_interaction_center);
 
-		EngagementModule.engageInternal(activity, interaction, TextModalInteraction.EVENT_NAME_LAUNCH);
 
 		TextView title = (TextView) activity.findViewById(R.id.title);
 		if (interaction.getTitle() == null) {
@@ -156,11 +155,6 @@ public class TextModalInteractionView extends InteractionView<TextModalInteracti
 		} else {
 			bottomArea.setVisibility(View.GONE);
 		}
-	}
-
-	@Override
-	public void onStop() {
-
 	}
 
 	@Override

--- a/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/UpgradeMessageInteractionView.java
+++ b/apptentive/src/com/apptentive/android/sdk/module/engagement/interaction/view/UpgradeMessageInteractionView.java
@@ -11,6 +11,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
+import android.os.Bundle;
 import android.view.View;
 import android.webkit.WebView;
 import android.widget.ImageView;
@@ -25,7 +26,6 @@ import com.apptentive.android.sdk.module.engagement.interaction.model.UpgradeMes
  */
 public class UpgradeMessageInteractionView extends InteractionView<UpgradeMessageInteraction> {
 
-	private static final String CODE_POINT_LAUNCH = "launch";
 	private static final String CODE_POINT_DISMISS = "dismiss";
 
 	public UpgradeMessageInteractionView(UpgradeMessageInteraction interaction) {
@@ -33,11 +33,8 @@ public class UpgradeMessageInteractionView extends InteractionView<UpgradeMessag
 	}
 
 	@Override
-	public void show(Activity activity) {
-		super.show(activity);
+	public void doOnCreate(Activity activity, Bundle savedInstanceState) {
 		activity.setContentView(R.layout.apptentive_upgrade_message_interaction);
-
-		EngagementModule.engageInternal(activity, interaction, CODE_POINT_LAUNCH);
 
 		ImageView iconView = (ImageView) activity.findViewById(R.id.icon);
 		Drawable icon = getIconDrawableResourceId(activity);
@@ -57,10 +54,6 @@ public class UpgradeMessageInteractionView extends InteractionView<UpgradeMessag
 				branding.setVisibility(View.GONE);
 			}
 		}
-	}
-
-	@Override
-	public void onStop() {
 	}
 
 	@Override

--- a/samples/apptentive-dev/apptentive-dev.iml
+++ b/samples/apptentive-dev/apptentive-dev.iml
@@ -99,7 +99,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 15 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android 4.0.3 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" name="HockeySDK-3.5.0" level="project" />
     <orderEntry type="module" module-name="apptentive" exported="" />

--- a/samples/apptentive-example/apptentive-example.iml
+++ b/samples/apptentive-example/apptentive-example.iml
@@ -79,7 +79,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 15 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android 4.0.3 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="apptentive" exported="" />
   </component>

--- a/tests/test-app/test-app.iml
+++ b/tests/test-app/test-app.iml
@@ -81,7 +81,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 15 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android 4.0.3 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="apptentive" exported="" />
   </component>


### PR DESCRIPTION
...and use that to track Interaction launch across orientation changes, so that Interaction launch Events are only sent once per real Interaction launch. NavigateToLinkInteraction and AppStoreRatingInteraction are exempt from this. Also fixes an issue where Surveys could be shown again if the screen orientation changed after they were submitted.