### PR TITLE
Resolve issues with Android 11 preventing surveys / dialogs from being shown

### DIFF
--- a/apptentive/build.gradle
+++ b/apptentive/build.gradle
@@ -21,12 +21,12 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.1'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 30
         // BUILD_NUMBER is provided by Jenkins. Default to 1 in dev builds.
         versionCode System.getenv("BUILD_NUMBER") as Integer ?: System.getenv("TRAVIS_BUILD_NUMBER") as Integer ?: 1
         versionName project.version

--- a/apptentive/src/androidTest/java/com/apptentive/android/sdk/storage/DeviceManagerTest.java
+++ b/apptentive/src/androidTest/java/com/apptentive/android/sdk/storage/DeviceManagerTest.java
@@ -1,0 +1,44 @@
+package com.apptentive.android.sdk.storage;
+
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(AndroidJUnit4.class)
+public class DeviceManagerTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void whenAndroidIdIsNull_thenExpectIllegalArgument() {
+        new DeviceManager(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenAndroidIdIsEmpty_thenExpectIllegalArgument() {
+        new DeviceManager("");
+    }
+
+    @Test
+    public void whenAndroidIdIsSet_thenExpectNoException() {
+        new DeviceManager(UUID.randomUUID().toString());
+    }
+
+    @Test
+    public void whenGeneratingDevice_thenExpectNoException() {
+        String androidID = UUID.randomUUID().toString();
+
+        DeviceManager deviceManager = new DeviceManager(androidID);
+        assertNotNull(deviceManager);
+
+        Device device = deviceManager.generateNewDevice(InstrumentationRegistry.getContext());
+        assertNotNull(device);
+
+        assertEquals("Android", device.getOsName());
+        assertEquals(androidID, device.getUuid());
+    }
+}

--- a/apptentive/src/main/java/com/apptentive/android/sdk/util/Constants.java
+++ b/apptentive/src/main/java/com/apptentive/android/sdk/util/Constants.java
@@ -176,6 +176,7 @@ public class Constants {
 	 * A list of mobile carrier network types as Strings.
 	 * From {@link android.telephony.TelephonyManager TelephonyManager}
 	 * @see android.telephony.TelephonyManager
+	 * @see <a href="https://developer.android.com/reference/android/telephony/TelephonyManager#getDataNetworkType()">getDataNetworkType()</a>
 	 */
 	private static final String[] networkTypeLookup = {
 		"UNKNOWN", //  0
@@ -196,7 +197,9 @@ public class Constants {
 		"HSPAP",   // 15
 		"GSM",     // 16
 		"TD_SCDMA",// 17
-		"IWLAN"    // 18
+		"IWLAN",   // 18
+		"UNKNOWN", // 19, skipped by Google
+		"5G"       // 20
 	};
 
 	public static String networkTypeAsString(int networkTypeAsInt) {

--- a/samples/apptentive-example/build.gradle
+++ b/samples/apptentive-example/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 30
+    buildToolsVersion '30.0.1'
 
 
     defaultConfig {

--- a/tests/test-app/build.gradle
+++ b/tests/test-app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
 
     defaultConfig {
@@ -14,6 +14,7 @@ android {
     lintOptions {
         abortOnError false
     }
+    buildToolsVersion '30.0.1'
 
     defaultConfig {
         testApplicationId "com.apptentive.android.sdk.tests"


### PR DESCRIPTION
Resolves #208 
I have submitted the contributor agreement.

This PR adds unit tests to verify existing function was not changed. The tests also verify the exception in DeviceManager happened before the code changes were made. 5G radio support was also added.

To resolve this issue, I have added a version check that keeps functionality the same if the build version is less than 30. On SDK 30 and newer, I check the READ_PHONE_STATE permission and verify that it is granted before attempting to use it.

The 5G radio type added in SDK 29 is also now supported.


If an app wants to provide surveys off the network type, the app can request READ_PHONE_STATE from the user still